### PR TITLE
Downgrade firelock version to support Ubuntu 18.04 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 default_wallet.webcash
+LOCK

--- a/miner.py
+++ b/miner.py
@@ -122,6 +122,12 @@ def mine():
                 "new_webcashes": [str(new_webcash)],
                 "legalese": webcash_wallet["legalese"],
             }
+            # Save the webcash to the wallet in case there is a network error
+            # while attempting to replace it.
+            unconfirmed_webcash = keep_webcash + [str(new_webcash)]
+            webcash_wallet["unconfirmed"].extend(unconfirmed_webcash)
+            save_webcash_wallet(webcash_wallet)
+            # Attempt replacement (should not fail!)
             replace_response = requests.post("https://webcash.tech/api/v1/replace", json=replace_request)
             if replace_response.status_code != 200:
                 # might happen if difficulty changed against us during mining
@@ -136,6 +142,10 @@ def mine():
                 # remove old webcashes
                 for wc in previous_webcashes:
                     webcash_wallet["webcash"].remove(str(wc))
+
+                # remove "unconfirmed" webcash
+                for wc in unconfirmed_webcash:
+                    webcash_wallet["unconfirmed"].remove(wc)
 
                 # save new webcash
                 #webcash = data["webcash"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click==8.0.3
 requests==2.27.1
-filelock==3.4.2
+filelock==3.4.1


### PR DESCRIPTION
There's no difference between 3.4.2 (latest) and 3.4.1, except availability on older python versions, such as Python 3.6 which is used on Ubuntu 18.04 LTS. Downgrading this dependency version gets us working out of the box on more platforms.