### PR TITLE
Need to import from webcash package to avoid import error

### DIFF
--- a/miner.py
+++ b/miner.py
@@ -24,7 +24,7 @@ from webcash.walletclient import (
     generate_new_secret,
 )
 
-from utils import lock_wallet
+from webcash.utils import lock_wallet
 
 INTERVAL_LENGTH_IN_SECONDS = 10
 


### PR DESCRIPTION
The reference `miner.py` was broken because it was trying to import `utils` which is no longer in the same directory.