### PR TITLE
Fix off-by-one error in walletdepth calculation.

### DIFF
--- a/webcash/walletclient.py
+++ b/webcash/walletclient.py
@@ -380,7 +380,7 @@ def recover(gaplimit):
         if reported_walletdepth > last_used_walletdepth + 1:
             print(f"Something may have gone wrong: reported walletdepth was {reported_walletdepth} but only found up to {last_used_walletdepth} depth")
 
-        if reported_walletdepth < last_used_walletdepth:
+        if reported_walletdepth <= last_used_walletdepth:
             webcash_wallet["walletdepths"][chain_code] = last_used_walletdepth + 1
 
     # TODO: only save the wallet when it has been modified?


### PR DESCRIPTION
If the reported wallet depth in the wallet is one less than the actual walletdepth, the recovery code did not fix it.  This commit commit fixes that off-by-1 error.